### PR TITLE
Implement logging of curl style requests for debugging

### DIFF
--- a/apollo/__init__.py
+++ b/apollo/__init__.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 from cachetools import TTLCache
 from apollo.util import AssertUser
@@ -17,6 +18,10 @@ userCache = TTLCache(
     10,  # Up to 2 items
     60  # 1 minute cache life
 )
+
+
+def set_logging_level(level):
+    logging.basicConfig(level=getattr(logging, level.upper()))
 
 
 class ApolloInstance(object):

--- a/apollo/client.py
+++ b/apollo/client.py
@@ -7,7 +7,6 @@ from shlex import quote
 log = logging.getLogger()
 
 
-
 class Client(object):
     """
     Base client class implementing methods to make requests to the server

--- a/apollo/client.py
+++ b/apollo/client.py
@@ -2,6 +2,10 @@
 """
 import json
 import requests
+import logging
+from shlex import quote
+log = logging.getLogger()
+
 
 
 class Client(object):
@@ -34,6 +38,12 @@ class Client(object):
             'username': self._wa.username,
             'password': self._wa.password,
         })
+
+        curl_command = ['curl', url]
+        for (k, v) in headers.items():
+            curl_command += ['-H', quote('%s: %s' % (k, v))]
+        curl_command += ['-d', quote(json.dumps(data))]
+        log.info(' '.join(curl_command))
 
         resp = requests.post(url, data=json.dumps(data),
                              headers=headers, verify=self.__verify,

--- a/arrow/cli.py
+++ b/arrow/cli.py
@@ -7,6 +7,7 @@ import json
 from .io import error
 from .config import read_global_config, global_config_path  # noqa, ditto
 from .apollo import get_apollo_instance
+from apollo import set_logging_level
 from arrow import __version__  # noqa, ditto
 
 CONTEXT_SETTINGS = dict(auto_envvar_prefix='ARROW', help_option_names=['-h', '--help'])
@@ -121,11 +122,21 @@ class ArrowCLI(click.MultiCommand):
     show_default=True,
     required=True
 )
+@click.option(
+    "-l",
+    "--log-level",
+    help='Logging level',
+    type=click.Choice(['debug', 'info', 'warn', 'error', 'critical']),
+    default='warn',
+    show_default=True,
+)
 @pass_context
-def arrow(ctx, apollo_instance, verbose):
+def arrow(ctx, apollo_instance, verbose, log_level):
     """Command line wrappers around Apollo functions. While this sounds
     unexciting, with arrow and jq you can easily build powerful command line
     scripts."""
+    set_logging_level(log_level)
+
     # We abuse this, knowing that calls to one will fail.
     try:
         ctx.gi = get_apollo_instance(apollo_instance)


### PR DESCRIPTION
Now all arrow commands have a `--log-level` flag which allows for logging curl-style requests:

```console
$ arrow -a eu -l info users update_user bot@usegalaxy.eu
INFO:root:curl https://apollo.usegalaxy.eu/apollo_api/user/loadUsers \
  -H 'Content-Type: application/json' \
  -d '{"username": "admin@usegalaxy.eu", "password": "<redacted>", "userId": "bot@usegalaxy.eu"}'
INFO:root:curl https://apollo.usegalaxy.eu/apollo_api/user/updateUser \
  -H 'Content-Type: application/json' \
  -d '{"availableGroups": [], "role": "USER", "password": "<redacted>", "newPassword": "", "userId": 24, "firstName": "Test", "organismPermissions": [], "username": "admin@usegalaxy.eu", "groups": [], "lastName": "User"}'
```

(Manually redacted passwords, manually broken lines). Nice for submitting bug reports since these reuqests are easier for non-python-apollo users to reproduce.