### PR TITLE
Fix support for python2.7

### DIFF
--- a/apollo/client.py
+++ b/apollo/client.py
@@ -3,12 +3,10 @@
 import json
 import requests
 import logging
-
 try:
     from shlex import quote
 except ImportError:
     from pipes import quote
-
 log = logging.getLogger()
 
 

--- a/apollo/client.py
+++ b/apollo/client.py
@@ -3,7 +3,12 @@
 import json
 import requests
 import logging
-from shlex import quote
+
+try:
+    from shlex import quote
+except ImportError:
+    from pipes import quote
+
 log = logging.getLogger()
 
 


### PR DESCRIPTION
Hi,
"from shlex import quote" is only available for python3 upwards, leading to crash with python 2.7.

The legacy lib for 2.7 is "pipes", so I added a try/catch statement.