### PR TITLE
initial add of dockerization of tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ docs/_build
 test_harness.py
 
 apollo_shared_dir
+
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
 FROM python:3.7
-MAINTAINER Nathan Dunn <nathandunn@lbl.gov>
+MAINTAINER Nathan Dunn <nathandunn>, Anthony Bretadeau <abretaud>, Helena Rasche <erasche>
 ENV DEBIAN_FRONTEND noninteractive
-
-# RUN apt-get -qq update --fix-missing && \
-#     apt-get --no-install-recommends -y install \
-#     git build-essential wget \
-#     curl ssl-cert zip unzip docker
-
-
-# RUN apt-get -qq update --fix-missing && \
-#     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /apollo/
 
 
 COPY . /app
@@ -21,14 +12,14 @@ RUN python setup.py install
 RUN apt-get -qq update --fix-missing && \
 	apt-get --no-install-recommends -y install \
 	docker git build-essential wget apt-utils \
-	curl ssl-cert zip unzip docker sudo
+	curl ssl-cert zip unzip sudo
 
 
 # TODO: maybe move to a separate script to be called with docker run python-apollo:latest test-apollo
 RUN pip install -U pip setuptools nose
 RUN export ARROW_GLOBAL_CONFIG_PATH=`pwd`/test-data/arrow.yml
-RUN ./bootstrap_apollo.sh
-RUN python setup.py nosetests
+# RUN ./bootstrap_apollo.sh
+# RUN python setup.py nosetests
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM python:3.7
+MAINTAINER Nathan Dunn <nathandunn@lbl.gov>
+ENV DEBIAN_FRONTEND noninteractive
+
+# RUN apt-get -qq update --fix-missing && \
+#     apt-get --no-install-recommends -y install \
+#     git build-essential wget \
+#     curl ssl-cert zip unzip docker
+
+
+# RUN apt-get -qq update --fix-missing && \
+#     apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /apollo/
+
+
+COPY . /app
+WORKDIR /app
+RUN pip install -r requirements.txt
+RUN python setup.py install
+
+
+RUN apt-get -qq update --fix-missing && \
+	apt-get --no-install-recommends -y install \
+	docker git build-essential wget apt-utils \
+	curl ssl-cert zip unzip docker sudo
+
+
+# TODO: maybe move to a separate script to be called with docker run python-apollo:latest test-apollo
+RUN pip install -U pip setuptools nose
+RUN export ARROW_GLOBAL_CONFIG_PATH=`pwd`/test-data/arrow.yml
+RUN ./bootstrap_apollo.sh
+RUN python setup.py nosetests
+
+
+
+
+
+

--- a/arrow-test.sh
+++ b/arrow-test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export ARROW_GLOBAL_CONFIG_PATH=`pwd`/test-data/arrow.yml
+./bootstrap_apollo.sh
+python setup.py nosetests


### PR DESCRIPTION
Doesn't quite work (installs, but the `bootstrap_apollo.sh` doesn't quite work) as it doesn't understand docker or sudo from the initial context.

Something  like this should work 

docker run bf1ad0638c63 /app/bootstrap_apollo.sh 

But we get 

docker run bf1ad0638c63 /app/bootstrap_apollo.sh 
/app/bootstrap_apollo.sh: line 6: docker: command not found
[BOOTSTRAP] Waiting while Apollo starts up...


